### PR TITLE
Remove extraneous z flag from tar calls

### DIFF
--- a/Build Dependencies/Libraries/build_libgcrypt.sh
+++ b/Build Dependencies/Libraries/build_libgcrypt.sh
@@ -6,7 +6,7 @@ pushd "${LIBRARY_WORKING_DIRECTORY_LOCATION}"
 
 curl -LO "https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${LIBRARY_GCRYPT_VERSION}.tar.bz2"  --retry 5
 
-tar -xvzf "./libgcrypt-${LIBRARY_GCRYPT_VERSION}.tar.bz2"
+tar -xvf "./libgcrypt-${LIBRARY_GCRYPT_VERSION}.tar.bz2"
 
 mv "./libgcrypt-${LIBRARY_GCRYPT_VERSION}" "./libgcrypt-source"
 

--- a/Build Dependencies/Libraries/build_libgpg-error.sh
+++ b/Build Dependencies/Libraries/build_libgpg-error.sh
@@ -6,7 +6,7 @@ pushd "${LIBRARY_WORKING_DIRECTORY_LOCATION}"
 
 curl -LO "https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-${LIBRARY_GPG_ERROR_VERSION}.tar.bz2" --retry 5
 
-tar -xvzf "./libgpg-error-${LIBRARY_GPG_ERROR_VERSION}.tar.bz2"
+tar -xvf "./libgpg-error-${LIBRARY_GPG_ERROR_VERSION}.tar.bz2"
 
 mv "./libgpg-error-${LIBRARY_GPG_ERROR_VERSION}" "./libgpg-error-source"
 

--- a/Build Dependencies/Libraries/build_libotr.sh
+++ b/Build Dependencies/Libraries/build_libotr.sh
@@ -6,7 +6,7 @@ pushd "${LIBRARY_WORKING_DIRECTORY_LOCATION}"
 
 curl -LO "https://otr.cypherpunks.ca/libotr-${LIBRARY_OTR_VERSION}.tar.gz" --retry 5
 
-tar -xvzf "./libotr-${LIBRARY_OTR_VERSION}.tar.gz"
+tar -xvf "./libotr-${LIBRARY_OTR_VERSION}.tar.gz"
 
 mv "./libotr-${LIBRARY_OTR_VERSION}" "./libotr-source"
 

--- a/Build Dependencies/Libraries/build_libressl.sh
+++ b/Build Dependencies/Libraries/build_libressl.sh
@@ -6,7 +6,7 @@ pushd "${LIBRARY_WORKING_DIRECTORY_LOCATION}"
 
 curl -LO "http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${LIBRARY_LIBRESSL_VERSION}.tar.gz" --retry 5
 
-tar -xvzf "./libressl-${LIBRARY_LIBRESSL_VERSION}.tar.gz"
+tar -xvf "./libressl-${LIBRARY_LIBRESSL_VERSION}.tar.gz"
 
 mv "./libressl-${LIBRARY_LIBRESSL_VERSION}" "./libressl-source"
 


### PR DESCRIPTION
Hi there! I found a curious issue when trying to build Textual: my builds kept failing with odd `mv` errors. After some careful inspection of the build output, I discovered that tar was trying to un-`gzip` what were actually `bzip2`archives. 

Eventually I found the build scripts here in Encryption-Kit and saw that tar was being called with the `-z` flag, which specifies gzip specifically. This isn't a problem with BSD tar, since I guess it ignores the flag when not invoked with `-c`. It was a problem, however, since I was using GNU tar on my machine, which actually respects the `-z` flag and was adamant on un-gzipping the bz2 archives that were being curled down.

I considered changing the flag to `-j`, which explicitly specifies bzip archives, but it turns out that just using `tar -xvf` works fine with both GNU and BSD tar, and on both gzip and bzip archives.